### PR TITLE
manifest-template.xml.envsubst: use new repo location instead of forwards

### DIFF
--- a/manifest-template.xml.envsubst
+++ b/manifest-template.xml.envsubst
@@ -8,31 +8,31 @@
   
   <project groups="minilayout" name="appc/acbuild" path="src/third_party/appc-acbuild" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="appc/spec" path="src/third_party/appc-spec" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/afterburn" path="src/third_party/afterburn" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/baselayout" path="src/third_party/baselayout" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/bootengine" path="src/third_party/bootengine" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/coreos-cloudinit" path="src/third_party/coreos-cloudinit" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/coreos-overlay" path="src/third_party/coreos-overlay" revision="$OVERLAY_REF" upstream="$OVERLAY_REF"/>
-  <project groups="minilayout" name="kinvolk/flatcar-dev-util" path="src/platform/dev" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/afterburn" path="src/third_party/afterburn" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/baselayout" path="src/third_party/baselayout" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/bootengine" path="src/third_party/bootengine" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/coreos-cloudinit" path="src/third_party/coreos-cloudinit" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/coreos-overlay" path="src/third_party/coreos-overlay" revision="$OVERLAY_REF" upstream="$OVERLAY_REF"/>
+  <project groups="minilayout" name="flatcar-linux/flatcar-dev-util" path="src/platform/dev" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
   <project groups="minilayout" name="kinvolk/docker" path="src/third_party/docker" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/fero" path="src/third_party/fero" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/grub" path="src/third_party/grub" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/ignition" path="src/third_party/ignition" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/init" path="src/third_party/init" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/locksmith" path="src/third_party/locksmith" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/mantle" path="src/third_party/mantle" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/mayday" path="src/third_party/mayday" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/nss-altfiles" path="src/third_party/nss-altfiles" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/portage-stable" path="src/third_party/portage-stable" revision="$PORTAGE_REF" upstream="$PORTAGE_REF"/>
-  <project groups="minilayout" name="kinvolk/flatcar-scripts" path="src/scripts" revision="$SCRIPTS_REF" upstream="$SCRIPTS_REF"/>
-  <project groups="minilayout" name="kinvolk/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/seismograph" path="src/third_party/seismograph" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/shim" path="src/third_party/shim" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/fero" path="src/third_party/fero" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/grub" path="src/third_party/grub" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/ignition" path="src/third_party/ignition" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/init" path="src/third_party/init" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/locksmith" path="src/third_party/locksmith" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/mantle" path="src/third_party/mantle" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/mayday" path="src/third_party/mayday" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/nss-altfiles" path="src/third_party/nss-altfiles" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/portage-stable" path="src/third_party/portage-stable" revision="$PORTAGE_REF" upstream="$PORTAGE_REF"/>
+  <project groups="minilayout" name="flatcar-linux/scripts" path="src/scripts" revision="$SCRIPTS_REF" upstream="$SCRIPTS_REF"/>
+  <project groups="minilayout" name="flatcar-linux/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/seismograph" path="src/third_party/seismograph" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/shim" path="src/third_party/shim" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
   <project groups="minilayout" name="kinvolk/systemd" path="src/third_party/systemd" revision="refs/heads/master" upstream="refs/heads/master"/>
-  <project groups="minilayout" name="kinvolk/toolbox" path="src/third_party/toolbox" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/torcx" path="src/third_party/torcx" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/update-ssh-keys" path="src/third_party/update-ssh-keys" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/update_engine" path="src/third_party/update_engine" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/updateservicectl" path="src/third_party/updateservicectl" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/toolbox" path="src/third_party/toolbox" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/torcx" path="src/third_party/torcx" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/update-ssh-keys" path="src/third_party/update-ssh-keys" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/update_engine" path="src/third_party/update_engine" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
+  <project groups="minilayout" name="flatcar-linux/updateservicectl" path="src/third_party/updateservicectl" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
   <project groups="minilayout" name="rkt/rkt" path="src/third_party/rkt" revision="refs/heads/master" upstream="refs/heads/master"/>
 </manifest>

--- a/manifest-template.xml.envsubst
+++ b/manifest-template.xml.envsubst
@@ -28,7 +28,6 @@
   <project groups="minilayout" name="flatcar-linux/sdnotify-proxy" path="src/third_party/sdnotify-proxy" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
   <project groups="minilayout" name="flatcar-linux/seismograph" path="src/third_party/seismograph" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
   <project groups="minilayout" name="flatcar-linux/shim" path="src/third_party/shim" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
-  <project groups="minilayout" name="kinvolk/systemd" path="src/third_party/systemd" revision="refs/heads/master" upstream="refs/heads/master"/>
   <project groups="minilayout" name="flatcar-linux/toolbox" path="src/third_party/toolbox" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
   <project groups="minilayout" name="flatcar-linux/torcx" path="src/third_party/torcx" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>
   <project groups="minilayout" name="flatcar-linux/update-ssh-keys" path="src/third_party/update-ssh-keys" revision="$DEFAULT_REF" upstream="$DEFAULT_REF"/>


### PR DESCRIPTION
also drops repos unused by LTS:
    
    The flatcar-lts-2605 branch still has ebuilds for rkt and docker
    (1.12, 17) pointing to the repos under the Kinvolk org but systemd
    points to upstream.
