### PR TITLE
Release repo setup: clone the repos including submodules

### DIFF
--- a/mirror-repos-branch
+++ b/mirror-repos-branch
@@ -50,7 +50,7 @@ for repo in "${FLATCAR_REPOS[@]}"; do
 
   HEAD_URL="git@github.com:flatcar-linux/${repo}"
 
-  [ ! -d "${repo}" ] && git clone "${HEAD_URL}"
+  [ ! -d "${repo}" ] && git clone --recurse-submodules "${HEAD_URL}"
 
   pushd "${repo}"
 

--- a/tag-release
+++ b/tag-release
@@ -40,7 +40,7 @@ for REPO in ${REPOS}; do
   echo "Preparing ${REPO}"
   cd "$SCRIPTFOLDER/.."
   if [ ! -d "${REPO}" ]; then
-    git clone "git@github.com:flatcar-linux/${REPO}.git"
+    git clone --recurse-submodules "git@github.com:flatcar-linux/${REPO}.git"
   fi
   cd "${REPO}"
   git fetch origin


### PR DESCRIPTION
The submodule update relies on the submodules being initialized,
make sure we do this when cloning the repo for the first time.

## How to use


## Testing done

None