### PR TITLE
upload_package: set json for Accept and Content-Type

### DIFF
--- a/upload_package
+++ b/upload_package
@@ -24,7 +24,8 @@ echo "Environment variable ARCH is specified as ${ARCH}"
 
 COREOS_APP_ID="e96281a6-d1af-4bde-9a0a-97b76e56dc57"
 
-. resty -W "${NEBRASKA_URL}/api" -H "Authorization: Bearer $GITHUB_TOKEN"
+. resty -W "${NEBRASKA_URL}/api" -H "Authorization: Bearer $GITHUB_TOKEN" \
+	-H "Accept: application/json" -H "Content-Type: application/json"
 
 UPDATE_PATH="${DATA_DIR}/flatcar_production_update.gz"
 UPDATE_CHECKSUM_PATH="${UPDATE_PATH}.sha256"


### PR DESCRIPTION
The `upload_package` script is already sending json metadata with POST requests.
However, as it does not set correct headers for that, Nebraska considered that as `application/x-www-form-urlencoded`.
As a result, Nebraska 2.6.0 or newer fails to accept the POST requests like:

```
{"message":"request body has an error: header Content-Type has
unexpected value \"application/x-www-form-urlencoded\""}
```

Set correct headers for the json type.

