### PR TITLE
upload_package: fix incompatibilities with Nebraska 2.6

### DIFF
--- a/upload_package
+++ b/upload_package
@@ -27,6 +27,21 @@ COREOS_APP_ID="e96281a6-d1af-4bde-9a0a-97b76e56dc57"
 . resty -W "${NEBRASKA_URL}/api" -H "Authorization: Bearer $GITHUB_TOKEN" \
 	-H "Accept: application/json" -H "Content-Type: application/json"
 
+function get_package_id() {
+	local tmpfile="$(mktemp)"
+	local package_id
+
+	GET /apps/"${COREOS_APP_ID}"/packages >& ${tmpfile}
+	if jq -e 'has("packages")' ${tmpfile} > /dev/null; then
+		package_id=$(cat ${tmpfile} | jq '.packages' | jq '.[] | select(.version=="'${VERSION}'" and .arch=='${ARCH_ID}').id')
+	else
+		package_id=$(cat ${tmpfile} | jq '.[] | select(.version=="'${VERSION}'" and .arch=='${ARCH_ID}').id')
+	fi
+	rm -f ${tmpfile}
+
+	echo ${package_id}
+}
+
 UPDATE_PATH="${DATA_DIR}/flatcar_production_update.gz"
 UPDATE_CHECKSUM_PATH="${UPDATE_PATH}.sha256"
 UPDATE_URL="https://${SUBDOMAIN}.release.flatcar-linux.net/${ARCH}/${VERSION}"/
@@ -54,7 +69,7 @@ else
   exit 1
 fi
 
-if ! PACKAGE_ID=$(GET /apps/"${COREOS_APP_ID}"/packages 2>&1 | jq '.[] | select(.version=="'${VERSION}'" and .arch=='${ARCH_ID}').id'); then
+if ! PACKAGE_ID=$(get_package_id); then
 	echo "Failed to get metadata from Nebraska."
 	echo "Please make sure that you have configured a valid GITHUB_TOKEN."
 	exit 1

--- a/upload_package
+++ b/upload_package
@@ -80,15 +80,16 @@ echo "Uploading update payload"
 if [ -z "${PACKAGE_ID}" ]; then
     if ! PACKAGE_ID=$(POST /apps/"${COREOS_APP_ID}"/packages " \
         {
-            \"filename\": \"$(basename ${UPDATE_PATH})\",
-            \"description\": \"Flatcar Linux ${VERSION}\",
-            \"url\": \"${UPDATE_URL}\",
-            \"version\": \"${VERSION}\",
-            \"type\": 1,
-            \"size\": \"${PAYLOAD_SIZE}\",
-            \"hash\": \"${PAYLOAD_SHA1}\",
             \"application_id\": \"${COREOS_APP_ID}\",
             \"arch\": ${ARCH_ID},
+            \"channels_blacklist\": [],
+            \"description\": \"Flatcar Linux ${VERSION}\",
+            \"filename\": \"$(basename ${UPDATE_PATH})\",
+            \"hash\": \"${PAYLOAD_SHA1}\",
+            \"size\": \"${PAYLOAD_SIZE}\",
+            \"type\": 1,
+            \"url\": \"${UPDATE_URL}\",
+            \"version\": \"${VERSION}\",
             \"flatcar_action\":
                 {
                     \"sha256\": \"${PAYLOAD_SHA256}\"


### PR DESCRIPTION
* With Nebraska 2.6.0 or newer, GET request returns a json output, which starts all relevant fields under the `.package` field.
We should check if that field exists, to support both 2.6 and pre-2.6.
Split the GET request part into `get_package_id`.
  * See also https://github.com/kinvolk/nebraska/blob/dfc08d64bc1a453a4dc411db66139650222b7985/backend/pkg/handler/packages.go#L192 .

* As Nebraska 2.6.0 or newer requires a channels_blacklist (array of strings) to be passed in every POST request, we need to pass an empty array.
  * See also https://github.com/kinvolk/nebraska/blob/dfc08d64bc1a453a4dc411db66139650222b7985/backend/api/spec.yaml#L1249



## Testing done

Local test done with Nebraska 2.6.

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
