### PR TITLE
package-diff: remove dependency on bc

### DIFF
--- a/package-diff
+++ b/package-diff
@@ -54,10 +54,10 @@ if [ "$FILE" = flatcar_production_image_contents.txt ] || [ "$FILE" = flatcar_de
     sed -i -E 's#[0-9]+\.[0-9]+\.[0-9]+-flatcar#a.b.c-flatcar#g' "$A" "$B"
   fi
   if [ "$CALCSIZE" = 1 ]; then
-    A_SUM=$(grep -v '^d' "$A" | grep -v '^l' | rev | cut -d ' ' -f 2 | rev | paste -sd+ - | bc)
-    echo "$(echo "${A_SUM}/1024/1024" | bc) MiB" > "$A"
-    B_SUM=$(grep -v '^d' "$B" | grep -v '^l' | rev | cut -d ' ' -f 2 | rev | paste -sd+ - | bc)
-    echo "$(echo "${B_SUM}/1024/1024" | bc) MiB" > "$B"
+    A_SUM=$(($(grep -v '^d' "$A" | grep -v '^l' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    echo "$((${A_SUM}/1024/1024)) MiB" > "$A"
+    B_SUM=$(($(grep -v '^d' "$B" | grep -v '^l' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    echo "$((${B_SUM}/1024/1024)) MiB" > "$B"
   fi
 fi
 

--- a/package-diff
+++ b/package-diff
@@ -54,9 +54,9 @@ if [ "$FILE" = flatcar_production_image_contents.txt ] || [ "$FILE" = flatcar_de
     sed -i -E 's#[0-9]+\.[0-9]+\.[0-9]+-flatcar#a.b.c-flatcar#g' "$A" "$B"
   fi
   if [ "$CALCSIZE" = 1 ]; then
-    A_SUM=$(($(grep -v '^d' "$A" | grep -v '^l' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    A_SUM=$(($(grep -v '^d' "$A" | grep -v '^l' | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
     echo "$((${A_SUM}/1024/1024)) MiB" > "$A"
-    B_SUM=$(($(grep -v '^d' "$B" | grep -v '^l' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    B_SUM=$(($(grep -v '^d' "$B" | grep -v '^l' | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
     echo "$((${B_SUM}/1024/1024)) MiB" > "$B"
   fi
 fi


### PR DESCRIPTION
- Bc is not available on Flatcar. Use $(()) expressions instead.
- replace unicode characters for reversing
  The cut command is a bit inflexible and thus reversing is used.
  However, that failed at least on Flatcar when unicode characters are
  encountered in SSL cert names.
  Replace unicode characters by '?'.

Tested with:
```
CALCSIZE=1 FILE=flatcar_production_image_contents.txt  CHANNEL_A=beta CHANNEL_B=alpha ./package-diff 3066.1.0 3127.0.0
```