### PR TITLE
package-diff: split up image size report by filesystems

### DIFF
--- a/package-diff
+++ b/package-diff
@@ -55,9 +55,21 @@ if [ "$FILE" = flatcar_production_image_contents.txt ] || [ "$FILE" = flatcar_de
   fi
   if [ "$CALCSIZE" = 1 ]; then
     A_SUM=$(($(grep -v '^d' "$A" | grep -v '^l' | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
-    echo "$((${A_SUM}/1024/1024)) MiB" > "$A"
+    A_BOOT=$(($(grep -v '^d' "$A" | grep -v '^l' | grep " [\.]*/boot" | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    A_USR=$(($(grep -v '^d' "$A" | grep -v '^l' | grep " [\.]*/usr" | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    A_ROOT=$(($(grep -v '^d' "$A" | grep -v '^l' | grep -v " [\.]*/usr" | grep -v " [\.]*/boot" | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    echo "Sum: $((${A_SUM}/1024/1024)) MiB" > "$A"
+    echo "Boot: $((${A_BOOT}/1024/1024)) MiB (must be < 60 MiB or updates will break)" >> "$A"
+    echo "Usr: $((${A_USR}/1024/1024)) MiB (inc. sparse files/hardlinks)" >> "$A"
+    echo "Rootfs: $((${A_ROOT}/1024/1024)) MiB" >> "$A"
     B_SUM=$(($(grep -v '^d' "$B" | grep -v '^l' | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
-    echo "$((${B_SUM}/1024/1024)) MiB" > "$B"
+    B_BOOT=$(($(grep -v '^d' "$B" | grep -v '^l' | grep " [\.]*/boot" | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    B_USR=$(($(grep -v '^d' "$B" | grep -v '^l' | grep " [\.]*/usr" | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    B_ROOT=$(($(grep -v '^d' "$B" | grep -v '^l' | grep -v " [\.]*/usr" | grep -v " [\.]*/boot" | tr -c '[:graph:][:space:]' '?' | rev | cut -d ' ' -f 2 | rev | paste -sd+ -)))
+    echo "Sum: $((${B_SUM}/1024/1024)) MiB" > "$B"
+    echo "Boot: $((${B_BOOT}/1024/1024)) MiB (must be < 60 MiB or updates will break)" >> "$B"
+    echo "Usr: $((${B_USR}/1024/1024)) MiB (inc. sparse files/hardlinks)" >> "$B"
+    echo "Rootfs: $((${B_ROOT}/1024/1024)) MiB" >> "$B"
   fi
 fi
 


### PR DESCRIPTION
Besides the sum of the file sizes the sum of each /usr, /boot, and
/ filesystems's files now gets printed. For the actual disk usage we
need to extend the generation of the metadata files to generate a new
file with the output of something like "df -h /boot/ /usr/ /".

## How to use/testing done

```
$ CALCSIZE=1 FILE=flatcar_production_image_contents.txt  CHANNEL_A=beta CHANNEL_B=alpha ./package-diff 3066.1.0 3127.0.0
diff --git a/tmp/3066.1.0-i6HXHj b/tmp/3127.0.0-dfEKFJ
index 3dc4111..6b9f7a7 100644
--- a/tmp/3066.1.0-i6HXHj
+++ b/tmp/3127.0.0-dfEKFJ
@@ -1,4 +1,4 @@
-Sum: 1158 MiB
-Boot: 46 MiB (must be < 60 MiB or updates will break)
-Usr: 1103 MiB (inc. sparse files/hardlinks)
-Rootfs: 8 MiB
+Sum: 1135 MiB
+Boot: 49 MiB (must be < 60 MiB or updates will break)
+Usr: 1073 MiB (inc. sparse files/hardlinks)
+Rootfs: 11 MiB
```