### PR TITLE
tag-release: do actions on submodules as well

### DIFF
--- a/tag-release
+++ b/tag-release
@@ -58,8 +58,8 @@ for REPO in ${REPOS}; do
       exit 1
     fi
     echo "Checking out scripts branch $MAINT-$MAJOR to update submodules"
-    git checkout -B "$MAINT-$MAJOR" "origin/$MAINT-$MAJOR" || { echo "Error: could not checkout the right branch in your 'scripts' repo" ; exit 1 ; }
-    git pull || { echo "Error: could not pull the branch in your 'scripts' repo" ; exit 1 ; }
+    git checkout --recurse-submodules -B "$MAINT-$MAJOR" "origin/$MAINT-$MAJOR" || { echo "Error: could not checkout the right branch in your 'scripts' repo" ; exit 1 ; }
+    git pull --recurse-submodules || { echo "Error: could not pull the branch in your 'scripts' repo" ; exit 1 ; }
     if [ "$(git log HEAD.."origin/$MAINT-$MAJOR")" != "" ] || ! git diff --quiet "origin/$MAINT-$MAJOR" ; then
       echo "Error: local changes in your 'scripts' repo"
       exit 1


### PR DESCRIPTION
Since the submodules get out of sync when something new gets checked
out, we can add the argument to update them as well.


## How to use

Retag a release

## Testing done

None