### PR TITLE
tag-release: port to new update_and_push_version function

### DIFF
--- a/tag-release
+++ b/tag-release
@@ -70,7 +70,7 @@ for REPO in ${REPOS}; do
       source ci-automation/ci_automation_common.sh
       update_submodules "${OVERLAY_REF}" "${PORTAGE_REF}"
       create_versionfile "${SDK_VERSION}" "${VERSION}"
-      SIGN=1 PUSH=1 update_and_push_version "${TAG}"
+      SIGN=1 update_and_push_version "${TAG}" true
     )
   else
     # Tag the other repos or the LTS scripts repo


### PR DESCRIPTION
The update_and_push_version function got changed from a PUSH env var to
a second argument. The tag-release script was not ported and thus
stopped pushing to the release maintenance branch.
Use the new argument instead of the env var.

## How to use


## Testing done

