### PR TITLE
upload_package: use single update subdomain, Use regular flatcar-VERSION branch for LTS 2022

### DIFF
--- a/create-manifest
+++ b/create-manifest
@@ -77,7 +77,7 @@ cp "$FILENAME" release.xml
 MAJOR="${VERSION%%.*}"
 
 MAINT="flatcar"
-if [ "$CHANNEL" = lts ]; then
+if [ "$CHANNEL" = lts ] && [ "$MAJOR" = "2605" ]; then
   MAINT="flatcar-lts"
 fi
 

--- a/tag-release
+++ b/tag-release
@@ -22,7 +22,7 @@ set -euo pipefail
 MAJOR="${VERSION%%.*}"
 
 MAINT="flatcar"
-if [ "$CHANNEL" = lts ]; then
+if [ "$CHANNEL" = lts ] && [ "$MAJOR" = "2605" ]; then
   MAINT="flatcar-lts"
 fi
 

--- a/upload_package
+++ b/upload_package
@@ -4,7 +4,7 @@ set -e
 shopt -s expand_aliases
 
 if [ $# -ne 4 ] && [ $# -ne 5 ]; then
-    echo "usage: ${0} DATA_DIR NEBRASKA_URL ORIGIN_SSH_URL VERSION [SUBDOMAIN]"
+    echo "usage: ${0} DATA_DIR NEBRASKA_URL ORIGIN_SSH_URL VERSION"
     exit 1
 fi
 
@@ -17,7 +17,6 @@ DATA_DIR="$1"
 NEBRASKA_URL="$2"
 ORIGIN_SSH_URL="$3"
 VERSION="$4"
-SUBDOMAIN="${5-update}"
 
 ARCH="${ARCH:-amd64-usr}"
 echo "Environment variable ARCH is specified as ${ARCH}"
@@ -44,7 +43,7 @@ function get_package_id() {
 
 UPDATE_PATH="${DATA_DIR}/flatcar_production_update.gz"
 UPDATE_CHECKSUM_PATH="${UPDATE_PATH}.sha256"
-UPDATE_URL="https://${SUBDOMAIN}.release.flatcar-linux.net/${ARCH}/${VERSION}"/
+UPDATE_URL="https://update.release.flatcar-linux.net/${ARCH}/${VERSION}"/
 
 PAYLOAD_SIZE=$(stat --format='%s' "${UPDATE_PATH}")
 PAYLOAD_SHA1=$(cat "${UPDATE_PATH}" | openssl dgst -sha1 -binary | base64)
@@ -54,7 +53,7 @@ sha256sum "${UPDATE_PATH}" > "${UPDATE_CHECKSUM_PATH}"
 
 echo "Copying update payload to update server"
 
-SERVER_UPDATE_DIR="/var/www/origin.release.flatcar-linux.net/${SUBDOMAIN}/${ARCH}/${VERSION}/"
+SERVER_UPDATE_DIR="/var/www/origin.release.flatcar-linux.net/update/${ARCH}/${VERSION}/"
 ssh "core@${ORIGIN_SSH_URL}" mkdir -p "${SERVER_UPDATE_DIR}"
 scp "${UPDATE_PATH}" "${UPDATE_CHECKSUM_PATH}" "core@${ORIGIN_SSH_URL}:${SERVER_UPDATE_DIR}"
 


### PR DESCRIPTION
The new LTS will be built from the regular release maintenance branches
    and mostly behave like the other channels with regard to how the
    releases are built from a major version branch while transitioning
    through the channels.

Store the update payloads always in one subdomain from now on instead
    of using a different subdomain for LTS.

## How to use



## Testing done

Will be tested (and fixed if necessary) during the release
