### PR TITLE
cherry-pick-for: Don't try to create branch but use existing one

### DIFF
--- a/cherry-pick-for
+++ b/cherry-pick-for
@@ -28,7 +28,7 @@ if [ "$BRANCH" = "--no-checkout-and-pull" ]; then
   BRANCH="HEAD"
 else
   echo "Checking out $BRANCH"
-  git checkout --recurse-submodules --track "$ORIGIN/$BRANCH"
+  git checkout --recurse-submodules "$BRANCH" || git checkout --recurse-submodules --track "$ORIGIN/$BRANCH"
   echo "Pulling $BRANCH"
   git pull --recurse-submodules
 fi


### PR DESCRIPTION
The checkout was meant to either check out an existing branch or create
the local branch tracking it from the origin. The --track option
however implied to create the branch always, thus failing when it
exists.
First try to check out the existing branch, then create a local branch
as fallback action.

## How to use


## Testing done

Works for meᵀᴹ

