### PR TITLE
tag-release: update tags of submodules to allow retagging

### DIFF
--- a/tag-release
+++ b/tag-release
@@ -68,6 +68,8 @@ for REPO in ${REPOS}; do
     (
       source sdk_lib/sdk_container_common.sh
       source ci-automation/ci_automation_common.sh
+      cd "sdk_container/src/third_party/coreos-overlay"; git fetch --all --tags --force; cd -
+      cd "sdk_container/src/third_party/portage-stable"; git fetch --all --tags --force; cd -
       update_submodules "${OVERLAY_REF}" "${PORTAGE_REF}"
       create_versionfile "${SDK_VERSION}" "${VERSION}"
       SIGN=1 update_and_push_version "${TAG}" true


### PR DESCRIPTION
When the tag-release script runs again it should use the new tags in
the submodules. However, the regular fetching bailed out since the
old ones would be overwritten.
Force a tag update in the submodules to allow retagging with the
tag-release script.

## How to use
Retag a release

## Testing done
Retagged a release