### PR TITLE
update-cloudformation-template: Use LTS instead of Edge

### DIFF
--- a/update-cloudformation-template
+++ b/update-cloudformation-template
@@ -178,7 +178,7 @@ function generate_templates() {
 
 mkdir -p files
 
-for c in alpha beta edge stable; do
+for c in alpha beta lts stable; do
     rm "$c.json" || true
     curl -s -S -f -Lo "$c.json" "https://${c}.release.flatcar-linux.net/${ARCH}/current/flatcar_production_ami_all.json" || true
     if [ -f "$c.json" ]; then


### PR DESCRIPTION
The channels that we need to update are changed here to include LTS
instead of Edge.

