### PR TITLE
is-pr-in-branches|package-diff: Remove Edge reference and use LTS

### DIFF
--- a/is-pr-in-branches
+++ b/is-pr-in-branches
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-DEFAULT_BRANCHES="origin/main origin/flatcar-master-edge"
+DEFAULT_BRANCHES="origin/main"
 
 if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Usage: $0 https://github.com/ORG/REPO/pull/NUMBER [branches...]"
@@ -21,7 +21,7 @@ BRANCHES="${@:2}"
 if [ "$BRANCHES" = "" ]; then
   BRANCHES="$DEFAULT_BRANCHES"
   PROPAGATED_MAJOR=""
-  for CHANNEL in stable beta alpha; do
+  for CHANNEL in lts stable beta alpha; do
     MAJOR=$(curl -s -S -f -L "https://${CHANNEL}.release.flatcar-linux.net/amd64-usr/current/version.txt" | grep -m 1 FLATCAR_BUILD= | cut -d = -f 2-)
     if [[ "$MAJOR" != "$PROPAGATED_MAJOR" ]]; then
       BRANCHES="$BRANCHES origin/flatcar-$MAJOR"

--- a/package-diff
+++ b/package-diff
@@ -6,7 +6,7 @@ if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Environment variables:"
   echo "Set FROM_(A|B)=(release|bincache) to select an other image location than the bucket"
   echo "Set BOARD_(A|B)=arm64-usr to select an arm64 build"
-  echo "Set CHANNEL_(A|B)=(alpha|beta|edge|developer) to select a build for another channel than stable"
+  echo "Set CHANNEL_(A|B)=(alpha|beta|lts|developer) to select a build for another channel than stable"
   echo "Set FILE=(flatcar_production_image_contents.txt|flatcar_developer_container_packages.txt|flatcar_developer_container_contents.txt|flatcar_production_image_kernel_config.txt)"
   echo "  to show image contents or developer container packages instead of flatcar_production_image_packages.txt"
   echo "Set MODE_(A|B)=/developer/ to select a developer build"


### PR DESCRIPTION
Edge is long gone and LTS is now a regular channel.


## How to use/Testing done


```
SHOW_PATCHES=0 ~/flatcar-linux/flatcar-build-scripts/is-pr-in-branches https://github.com/ORG/PROJ/pull/NUMBER
```



- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
