### PR TITLE
Sort changelog lines and CVEs

### DIFF
--- a/show-changes
+++ b/show-changes
@@ -47,7 +47,7 @@ for section in security bugfixes changes updates; do
     fi
     # TODO: when the coreos-overlay and portage-stable submodules are pointing to the right version, use them directly instead of "-C repo"
     # (and allow to operate in "scripts" instead of the top directory)
-    git -C "${repo}" difftool --no-prompt --extcmd='sh -c "cat \"$REMOTE\"" --' "${OLD}..${NEW}" -- "changelog/${section}/" || { echo "Error: git difftool failed" ; exit 1 ; }
+    git -C "${repo}" difftool --no-prompt --extcmd='sh -c "cat \"$REMOTE\"" --' "${OLD}..${NEW}" -- "changelog/${section}/" | sort || { echo "Error: git difftool failed" ; exit 1 ; }
     # The -x 'sh -c "cat \"$REMOTE\"" --' command assumes that new changes have their own changelog files,
     # and thus ignores the LOCAL file (which is the empty /dev/null) and prints out the REMOTE completly.
     # If an existing file got changed, we assume that this is just a correction for the old change but

--- a/show-fixed-kernel-cves.py
+++ b/show-fixed-kernel-cves.py
@@ -36,11 +36,14 @@ def print_fixed_linux_cves(from_version_str, to_version_str):
   streams = json.loads(payload)
   from_version=version.Version(from_version_str)
   to_version=version.Version(to_version_str)
+  cvelist = []
   links = []
   for stream, releases in streams.items():
     for release, cves in releases.items():
       if release != "outstanding" and from_version < version.Version(release) <= to_version:
-        links += [f"[{cve}](https://nvd.nist.gov/vuln/detail/{cve})" for cve, _ in cves.items()]
+        cvelist += cves.items()
+  for cve, _ in sorted(cvelist):
+    links += [f"[{cve}](https://nvd.nist.gov/vuln/detail/{cve})"]
   print(", ".join(links))
 
 parser = OptionParser()


### PR DESCRIPTION
In show-changes, before showing changes for each section, sort the lines alphabetically.

In show-fixed-kernel-cves, sort CVEs output numerically, e.g. CVE-2022-0001 before CVE-2022-0002.