### PR TITLE
show-changes: Autogenerate fixed kernel CVE entries

### DIFF
--- a/show-changes
+++ b/show-changes
@@ -40,8 +40,12 @@ for section in security bugfixes changes updates; do
   esac
   echo
   if [ "${section}" = security ]; then
-      FROM_KERNEL=$(git -C coreos-overlay show "${OLD}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
-      TO_KERNEL=$(git -C coreos-overlay show "${NEW}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
+      repo=coreos-overlay
+      if [ -d "scripts/sdk_container/src/third_party/${repo}" ]; then
+        repo="scripts/sdk_container/src/third_party/${repo}"
+      fi
+      FROM_KERNEL=$(git -C "${repo}" show "${OLD}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
+      TO_KERNEL=$(git -C "${repo}" show "${NEW}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
       if [ "${FROM_KERNEL}" != "${TO_KERNEL}" ]; then
         KERNEL_ENTRIES=$("${SCRIPTFOLDER}"/show-fixed-kernel-cves.py -f "${FROM_KERNEL}" -t "${TO_KERNEL}")
         if [ "${KERNEL_ENTRIES}" != "" ]; then
@@ -51,13 +55,16 @@ for section in security bugfixes changes updates; do
   fi
   for repo in coreos-overlay portage-stable scripts; do
     if [ "${repo}" = scripts ] && [ ! -e "${repo}" ]; then
+      # Support the previous repo name for old checkouts
       repo="flatcar-scripts"
+    fi
+    # For the submodule detection, assume that the "scripts" repo name is ok
+    if [ "${repo}" != "scripts" ] && [ -d "scripts/sdk_container/src/third_party/${repo}" ]; then
+      repo="scripts/sdk_container/src/third_party/${repo}"
     fi
     if [ "${FETCH}" = 1 ]; then
       git -C "${repo}" fetch -t -f 2> /dev/null > /dev/null || { echo "Error: git fetch -t -f failed" ; exit 1 ; }
     fi
-    # TODO: when the coreos-overlay and portage-stable submodules are pointing to the right version, use them directly instead of "-C repo"
-    # (and allow to operate in "scripts" instead of the top directory)
     git -C "${repo}" difftool --no-prompt --extcmd='sh -c "cat \"$REMOTE\"" --' "${OLD}..${NEW}" -- "changelog/${section}/" | sort || { echo "Error: git difftool failed" ; exit 1 ; }
     # The -x 'sh -c "cat \"$REMOTE\"" --' command assumes that new changes have their own changelog files,
     # and thus ignores the LOCAL file (which is the empty /dev/null) and prints out the REMOTE completly.

--- a/show-changes
+++ b/show-changes
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 FETCH="${FETCH-1}"
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
 
 if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Usage: $0 OLD [NEW]"
@@ -38,6 +39,16 @@ for section in security bugfixes changes updates; do
       exit 1
   esac
   echo
+  if [ "${section}" = security ]; then
+      FROM_KERNEL=$(git -C coreos-overlay show "${OLD}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
+      TO_KERNEL=$(git -C coreos-overlay show "${NEW}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
+      if [ "${FROM_KERNEL}" != "${TO_KERNEL}" ]; then
+        KERNEL_ENTRIES=$("${SCRIPTFOLDER}"/show-fixed-kernel-cves.py -f "${FROM_KERNEL}" -t "${TO_KERNEL}")
+        if [ "${KERNEL_ENTRIES}" != "" ]; then
+          echo "- Linux (${KERNEL_ENTRIES})"
+        fi
+      fi
+  fi
   for repo in coreos-overlay portage-stable scripts; do
     if [ "${repo}" = scripts ] && [ ! -e "${repo}" ]; then
       repo="flatcar-scripts"

--- a/show-changes
+++ b/show-changes
@@ -40,8 +40,8 @@ for section in security bugfixes changes updates; do
   esac
   echo
   if [ "${section}" = security ]; then
-      FROM_KERNEL=$(git -C coreos-overlay show "${OLD}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
-      TO_KERNEL=$(git -C coreos-overlay show "${NEW}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
+      FROM_KERNEL=$(git -C coreos-overlay show "${OLD}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
+      TO_KERNEL=$(git -C coreos-overlay show "${NEW}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
       if [ "${FROM_KERNEL}" != "${TO_KERNEL}" ]; then
         KERNEL_ENTRIES=$("${SCRIPTFOLDER}"/show-fixed-kernel-cves.py -f "${FROM_KERNEL}" -t "${TO_KERNEL}")
         if [ "${KERNEL_ENTRIES}" != "" ]; then


### PR DESCRIPTION
The manual invocation of show-fixed-kernel-cves.py meant that one needs
to find the right kernel versions which is prone to off-by-ones when
reading the update section.
Automate this to save a manual step and prevent mistakes.

## How to use/Testing done

```
# assuming you have all three repos scripts/coreos-overlay/portage-stable checked out in the current directory
flatcar-build-scripts/show-changes stable-3139.2.2 stable-3139.2.3
```