### PR TITLE
show-changes: Find submodules references

### DIFF
--- a/show-changes
+++ b/show-changes
@@ -39,33 +39,35 @@ for section in security bugfixes changes updates; do
       exit 1
   esac
   echo
-  if [ "${section}" = security ]; then
-      repo=coreos-overlay
-      if [ -d "scripts/sdk_container/src/third_party/${repo}" ]; then
-        repo="scripts/sdk_container/src/third_party/${repo}"
-      fi
-      FROM_KERNEL=$(git -C "${repo}" show "${OLD}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
-      TO_KERNEL=$(git -C "${repo}" show "${NEW}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
+  for repo in coreos-overlay portage-stable scripts; do
+    if [ "${repo}" = scripts ] && [ ! -e "${repo}" ]; then
+      # Support the previous repo name for old checkouts
+      repo="flatcar-scripts"
+    fi
+    OLDREF="${OLD}"
+    NEWREF="${NEW}"
+    REPOPATH="${repo}"
+    # For the submodule detection, assume that the "scripts" repo name is ok
+    if [ "${repo}" != "scripts" ] && [ -d "scripts/sdk_container/src/third_party/${repo}" ]; then
+      # Find the pinned submodule refs because there may be no release tags inside the submodules
+      OLDREF=$(git -C "scripts" ls-tree --object-only "${OLD}" "sdk_container/src/third_party/${repo}")
+      NEWREF=$(git -C "scripts" ls-tree --object-only "${NEW}" "sdk_container/src/third_party/${repo}")
+      REPOPATH="scripts/sdk_container/src/third_party/${repo}"
+    fi
+    if [ "${FETCH}" = 1 ]; then
+      git -C "${REPOPATH}" fetch -t -f 2> /dev/null > /dev/null || { echo "Error: git fetch -t -f failed" ; exit 1 ; }
+    fi
+    if [ "${section}" = "security" ] && [ "${repo}" = "coreos-overlay" ]; then
+      FROM_KERNEL=$(git -C "${REPOPATH}" show "${OLDREF}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
+      TO_KERNEL=$(git -C "${REPOPATH}" show "${NEWREF}":sys-kernel/coreos-kernel/ | grep -m 1 'coreos-kernel-.*\.ebuild' | cut -d - -f 3 | cut -d . -f 1-3)
       if [ "${FROM_KERNEL}" != "${TO_KERNEL}" ]; then
         KERNEL_ENTRIES=$("${SCRIPTFOLDER}"/show-fixed-kernel-cves.py -f "${FROM_KERNEL}" -t "${TO_KERNEL}")
         if [ "${KERNEL_ENTRIES}" != "" ]; then
           echo "- Linux (${KERNEL_ENTRIES})"
         fi
       fi
-  fi
-  for repo in coreos-overlay portage-stable scripts; do
-    if [ "${repo}" = scripts ] && [ ! -e "${repo}" ]; then
-      # Support the previous repo name for old checkouts
-      repo="flatcar-scripts"
     fi
-    # For the submodule detection, assume that the "scripts" repo name is ok
-    if [ "${repo}" != "scripts" ] && [ -d "scripts/sdk_container/src/third_party/${repo}" ]; then
-      repo="scripts/sdk_container/src/third_party/${repo}"
-    fi
-    if [ "${FETCH}" = 1 ]; then
-      git -C "${repo}" fetch -t -f 2> /dev/null > /dev/null || { echo "Error: git fetch -t -f failed" ; exit 1 ; }
-    fi
-    git -C "${repo}" difftool --no-prompt --extcmd='sh -c "cat \"$REMOTE\"" --' "${OLD}..${NEW}" -- "changelog/${section}/" | sort || { echo "Error: git difftool failed" ; exit 1 ; }
+    git -C "${REPOPATH}" difftool --no-prompt --extcmd='sh -c "cat \"$REMOTE\"" --' "${OLDREF}..${NEWREF}" -- "changelog/${section}/" | sort || { echo "Error: git difftool failed" ; exit 1 ; }
     # The -x 'sh -c "cat \"$REMOTE\"" --' command assumes that new changes have their own changelog files,
     # and thus ignores the LOCAL file (which is the empty /dev/null) and prints out the REMOTE completly.
     # If an existing file got changed, we assume that this is just a correction for the old change but


### PR DESCRIPTION
The usage of the same git reference for all repos only works for
releases. Dev builds may only have a tag in scripts and anyway we
would also want to support individual commits or branches as refs.
Resolve the pinned submodule refs and use them instead of requiring a
single valid ref for all three repos.

## How to use/Testing done
With only the "scripts" repo existing in the current directory
```
flatcar-build-scripts/show-changes stable-3139.2.2 stable-3139.2.3
```