### PR TITLE
show-changes: support git 2.32

### DIFF
--- a/show-changes
+++ b/show-changes
@@ -50,8 +50,9 @@ for section in security bugfixes changes updates; do
     # For the submodule detection, assume that the "scripts" repo name is ok
     if [ "${repo}" != "scripts" ] && [ -d "scripts/sdk_container/src/third_party/${repo}" ]; then
       # Find the pinned submodule refs because there may be no release tags inside the submodules
-      OLDREF=$(git -C "scripts" ls-tree --object-only "${OLD}" "sdk_container/src/third_party/${repo}")
-      NEWREF=$(git -C "scripts" ls-tree --object-only "${NEW}" "sdk_container/src/third_party/${repo}")
+      # Pipe to awk instead of using --object-only for git 2.35 support
+      OLDREF=$(git -C "scripts" ls-tree "${OLD}" "sdk_container/src/third_party/${repo}" | awk '{print $3 }')
+      NEWREF=$(git -C "scripts" ls-tree "${NEW}" "sdk_container/src/third_party/${repo}" | awk '{print $3 }')
       REPOPATH="scripts/sdk_container/src/third_party/${repo}"
     fi
     if [ "${FETCH}" = 1 ]; then


### PR DESCRIPTION
The ls-tree --object-only parameter is not supported in git 2.32 which
is the git version in Flatcar Stable and in use on our build servers.
Filter the output with awk to find the commit ID.

## How to use/Testing done
Needed for https://github.com/flatcar-linux/scripts/pull/375

I did the following to check it works on Flatcar Stable with a python3 command in PATH
```
FETCH=0 flatcar-build-scripts/show-changes stable-3139.2.2 stable-3139.2.3
```